### PR TITLE
Fix Bootstrap Col for Mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
       <div class="row">
         <!-- hides empty col below lg scr -->
         <div class="d-none d-lg-block col-md-4"></div>
-        <div class="col-8">
+        <div class="col-lg-8">
           <div class="card mb-3" style="max-width: 800px; background-color: rgba(245, 245, 245, 0.8);">
             <div class="row">
               <div class="col-lg-8">


### PR DESCRIPTION
Card 2 had class = "col-8" and created an inconsistent sizing of cards. inserted Col-lg-8 to make consistent styling.